### PR TITLE
fix: ensure contexts are initialized on component mount

### DIFF
--- a/view/src/components/AppSidebar.vue
+++ b/view/src/components/AppSidebar.vue
@@ -53,7 +53,7 @@ import {
   Trash2,
   UserRoundPen
 } from 'lucide-vue-next'
-import { computed, nextTick, onMounted, ref } from 'vue'
+import { computed, nextTick, ref } from 'vue'
 import { RouterLink, useRoute, useRouter } from 'vue-router'
 
 const navItems: { title: string; url: string; icon: typeof SquarePen; disabled?: boolean }[] = [
@@ -96,9 +96,6 @@ const store = useConversationsStore()
 const contextsStore = useContextsStore()
 const router = useRouter()
 
-onMounted(() => {
-  contextsStore.initializeContexts()
-})
 
 const editingConversationId = ref<string | null>(null)
 const nameInputs = ref<{ [convId: string]: HTMLInputElement }>({})

--- a/view/src/components/ContextSelection.vue
+++ b/view/src/components/ContextSelection.vue
@@ -52,7 +52,4 @@ const databasesStore = useDatabasesStore()
 
 const contextsStore = useContextsStore()
 
-onMounted(() => {
-  contextsStore.initializeContexts()
-})
 </script>

--- a/view/src/router.ts
+++ b/view/src/router.ts
@@ -41,17 +41,20 @@ const routes = [
   {
     path: '/chat/:id',
     name: 'ChatPage',
-    component: loadView('ChatPage')
+    component: loadView('ChatPage'),
+    meta: { requiresContext: true }
   },
   {
     path: '/editor',
     name: 'Editor',
-    component: loadView('Editor')
+    component: loadView('Editor'),
+    meta: { requiresContext: true }
   },
   {
     path: '/query/:id',
     name: 'Query',
     component: loadView('Editor'),
+    meta: { requiresContext: true },
     beforeEnter: async (to) => {
       const { loadQuery } = useQueryEditor()
       await loadQuery(to.params.id)
@@ -61,12 +64,14 @@ const routes = [
   {
     path: '/favorites',
     name: 'Favorites',
-    component: loadView('Favorites')
+    component: loadView('Favorites'),
+    meta: { requiresContext: true }
   },
   {
     path: '/databases',
     name: 'DatabaseList',
-    component: loadView('DatabaseList')
+    component: loadView('DatabaseList'),
+    meta: { requiresContext: true }
   },
   {
     path: '/databases/new',
@@ -77,12 +82,14 @@ const routes = [
   {
     path: '/databases/:id',
     name: 'DatabaseEdit',
-    component: loadView('DatabaseEdit')
+    component: loadView('DatabaseEdit'),
+    meta: { requiresContext: true }
   },
   {
     path: '/issues',
     name: 'IssuesPage',
-    component: loadView('Issues')
+    component: loadView('Issues'),
+    meta: { requiresContext: true }
   },
   {
     path: '/privacy',
@@ -92,28 +99,26 @@ const routes = [
   {
     path: '/projects',
     name: 'ProjectList',
-    component: loadView('ProjectList')
+    component: loadView('ProjectList'),
+    meta: { requiresContext: true }
   },
   {
     path: '/projects/:id',
     name: 'ProjectEdit',
     component: loadView('ProjectEdit'),
-    beforeEnter: async (to) => {
-      const contextsStore = useContextsStore()
-      await contextsStore.initializeContexts()
-      return true
-    }
+    meta: { requiresContext: true }
   },
   {
     path: '/user',
     name: 'User',
-    component: loadView('User')
+    component: loadView('User'),
+    meta: { requiresContext: true }
   },
   {
     path: '/control',
     name: 'Control',
     component: Control,
-    meta: { requiresAuth: true }
+    meta: { requiresAuth: true, requiresContext: true }
   },
   {
     path: '/:pathMatch(.*)*',
@@ -124,7 +129,8 @@ const routes = [
   {
     path: '/profile',
     name: 'Profile',
-    component: loadView('ProfilePage')
+    component: loadView('ProfilePage'),
+    meta: { requiresContext: true }
   }
 ]
 
@@ -134,5 +140,13 @@ const router = createRouter({
 })
 router.beforeEach(authGuard)
 router.beforeEach(redirectToWelcome)
+
+// Initialize contexts for routes that require them
+router.beforeEach(async (to) => {
+  if (to.meta.requiresContext) {
+    const contextsStore = useContextsStore()
+    await contextsStore.initializeContexts()
+  }
+})
 
 export default router


### PR DESCRIPTION
# Issue
If an old `databaseId` was in localStorage, no context was selected at page load.
Previously, context was handled by an component who init the context store and check for valid context or not. 

## Fix
Adding the context initialisation inside sidebar 