### PR TITLE
Remove unused pinia lib

### DIFF
--- a/view/package.json
+++ b/view/package.json
@@ -33,7 +33,6 @@
     "marked": "^14.0.0",
     "notiwind": "^2.1.0",
     "pinia": "^2.0.32",
-    "pinia-plugin-persistedstate": "^3.1.0",
     "postcss": "^8.5.4",
     "reka-ui": "^2.5.0",
     "socket.io-client": "^4.8.1",

--- a/view/src/main.ts
+++ b/view/src/main.ts
@@ -5,14 +5,12 @@ import router from '@/router'
 import * as Sentry from '@sentry/vue'
 import Notifications from 'notiwind'
 import { createPinia } from 'pinia'
-import piniaPluginPersistedState from 'pinia-plugin-persistedstate'
 import { createApp } from 'vue'
 import { createMetaManager } from 'vue-meta'
 import Vue3TouchEvents, { type Vue3TouchEventsOptions } from 'vue3-touch-events'
 
 const app = createApp(App)
 const pinia = createPinia()
-pinia.use(piniaPluginPersistedState)
 app.use(pinia)
 app.use(router)
 

--- a/view/yarn.lock
+++ b/view/yarn.lock
@@ -2988,11 +2988,6 @@ pify@^3.0.0:
   resolved "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz"
   integrity sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==
 
-pinia-plugin-persistedstate@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.npmjs.org/pinia-plugin-persistedstate/-/pinia-plugin-persistedstate-3.1.0.tgz"
-  integrity sha512-8UN+vYMEPBdgNLwceY08mi5olI0wkYaEb8b6hD6xW7SnBRuPydWHlEhZvUWgNb/ibuf4PvufpvtS+dmhYjJQOw==
-
 pinia@^2.0.32:
   version "2.0.33"
   resolved "https://registry.npmjs.org/pinia/-/pinia-2.0.33.tgz"


### PR DESCRIPTION
Remove `pinia-plugin-persistedstate` library because no Pinia stores were configured to use its persistence features.

---
Linear Issue: [DEV-363](https://linear.app/myriade/issue/DEV-363/remove-unused-pinia-lib)

<a href="https://cursor.com/background-agent?bcId=bc-19785273-a064-4c2d-9798-70f29c5dec3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-19785273-a064-4c2d-9798-70f29c5dec3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

