### PR TITLE
Fix chat scroll to last message

### DIFF
--- a/view/src/components/Chat.vue
+++ b/view/src/components/Chat.vue
@@ -435,20 +435,32 @@ onMounted(async () => {
   if (!conversationId.value) {
     // New conversation
     await fetchAISuggestions()
+    scrollToBottom()
   } else {
     // Existing conversation
-    conversationsStore.fetchMessages(conversationId.value)
+    await conversationsStore.fetchMessages(conversationId.value)
+    scrollToBottom()
   }
-
-  scrollToBottom()
 })
 
 // If route changes (user navigates to a different ID)
 watch(
   () => conversationId.value,
-  (newVal) => {
+  async (newVal) => {
     if (newVal !== null && newVal !== undefined && newVal !== '') {
-      conversationsStore.fetchMessages(newVal)
+      await conversationsStore.fetchMessages(newVal)
+      scrollToBottom()
+    }
+  }
+)
+
+// Watch for messages changes to auto-scroll when messages are loaded
+watch(
+  () => messages.value.length,
+  (newLength, oldLength) => {
+    // Only scroll if messages were added (not removed)
+    if (newLength > (oldLength || 0)) {
+      nextTick(() => scrollToBottom())
     }
   }
 )

--- a/view/src/components/Chat.vue
+++ b/view/src/components/Chat.vue
@@ -439,7 +439,8 @@ onMounted(async () => {
   } else {
     // Existing conversation
     await conversationsStore.fetchMessages(conversationId.value)
-    scrollToBottom()
+    // Wait for DOM to update with the messages before scrolling
+    nextTick(() => scrollToBottom())
   }
 })
 
@@ -449,21 +450,12 @@ watch(
   async (newVal) => {
     if (newVal !== null && newVal !== undefined && newVal !== '') {
       await conversationsStore.fetchMessages(newVal)
-      scrollToBottom()
-    }
-  }
-)
-
-// Watch for messages changes to auto-scroll when messages are loaded
-watch(
-  () => messages.value.length,
-  (newLength, oldLength) => {
-    // Only scroll if messages were added (not removed)
-    if (newLength > (oldLength || 0)) {
+      // Wait for DOM to update with the messages before scrolling
       nextTick(() => scrollToBottom())
     }
   }
 )
+
 
 /** AI SUGGESTIONS **/
 const aiSuggestions = ref([])


### PR DESCRIPTION
Ensure chat scrolls to the latest message when returning to a conversation or when messages are loaded.

---
Linear Issue: [DEV-337](https://linear.app/myriade/issue/DEV-337/scroll-des-chats)

<a href="https://cursor.com/background-agent?bcId=bc-f099dff9-3839-4720-987b-49be01f946cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f099dff9-3839-4720-987b-49be01f946cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

