### PR TITLE
feat: frontend feature flipping

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # Multi-stage build for single container Myriade deployment
 FROM node:lts-alpine AS frontend-build
 
+# Accept environment argument (defaults to production)
+ARG ENV=production
+
 # Build Vue.js frontend
 WORKDIR /app/view
 COPY view/package.json view/yarn.lock ./
@@ -8,7 +11,13 @@ ENV NODE_OPTIONS="--max_old_space_size=4096"
 RUN yarn install
 
 COPY view/ .
-RUN yarn build
+
+# Build with proper Vite mode
+RUN if [ "$ENV" = "staging" ]; then \
+        yarn build --mode staging; \
+    else \
+        yarn build --mode production; \
+    fi
 
 # Main application stage
 FROM python:3.11.4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,10 @@ services:
       - myriade-network
 
   myriade:
-    build: .
+    build:
+      context: .
+      args:
+        ENV: ${DOCKER_ENV:-production} 
     image: myriadeai/myriade:latest
     depends_on:
       - db

--- a/fly.toml
+++ b/fly.toml
@@ -3,6 +3,8 @@ app = "myriade"
 primary_region = "cdg"
 
 [build]
+  [build.args]
+    ENV = "staging" 
 
 [http_service]
   internal_port = 8080

--- a/view/src/App.vue
+++ b/view/src/App.vue
@@ -35,10 +35,14 @@
       </div>
     </div>
   </NotificationGroup>
+
+  <!-- Feature Flag Panel (Dev Only) -->
+  <FeatureFlagPanel />
 </template>
 
 <script lang="ts" setup>
 import BaseNotification from '@/components/base/BaseNotification.vue'
+import FeatureFlagPanel from '@/components/FeatureFlagPanel.vue'
 import { Notification, NotificationGroup } from 'notiwind'
 import { computed, defineAsyncComponent, onMounted, ref } from 'vue'
 

--- a/view/src/components/AppSidebar.vue
+++ b/view/src/components/AppSidebar.vue
@@ -37,6 +37,7 @@ import {
 import { logout, user } from '@/stores/auth'
 import { useContextsStore } from '@/stores/contexts'
 import { useConversationsStore } from '@/stores/conversations'
+import { useFeatureFlagsStore } from '@/stores/featureFlags'
 import {
   CalendarCog,
   ChevronsUpDown,
@@ -100,6 +101,7 @@ const navItems: { title: string; url: string; icon: typeof SquarePen; disabled?:
 
 const store = useConversationsStore()
 const contextsStore = useContextsStore()
+const featureFlagsStore = useFeatureFlagsStore()
 const router = useRouter()
 
 const editingConversationId = ref<string | null>(null)
@@ -115,6 +117,15 @@ function setNameInputRef(id: string) {
 
 const projects = computed(() => contextsStore.contexts.filter((c) => c.type === 'project'))
 const databases = computed(() => contextsStore.contexts.filter((c) => c.type === 'database'))
+
+const filteredNavItems = computed(() => {
+  return navItems.filter((item) => {
+    if (item.title === 'Catalog') {
+      return featureFlagsStore.isFeatureEnabled('catalog')
+    }
+    return true
+  })
+})
 
 const sortedGroup = computed(() => {
   return store.sortedUserConversations
@@ -212,7 +223,7 @@ async function handleDeleteConversation(conversationId: string) {
         <SidebarGroupContent>
           <SidebarMenu>
             <SidebarMenuItem
-              v-for="item in navItems.filter(({ disabled }) => !disabled)"
+              v-for="item in filteredNavItems.filter(({ disabled }) => !disabled)"
               :key="item.title"
             >
               <SidebarMenuButton asChild :isActive="isActive(item.url)" :tooltip="item.title">

--- a/view/src/components/FeatureFlagPanel.vue
+++ b/view/src/components/FeatureFlagPanel.vue
@@ -1,0 +1,48 @@
+<template>
+  <div v-if="isDevelopment" class="fixed bottom-4 right-4 z-50">
+    <Card v-if="isExpanded" class="mb-2 w-72 gap-0">
+      <CardHeader class="pb-3">
+        <div class="flex items-center justify-between">
+          <CardTitle class="text-sm">Feature Flags</CardTitle>
+          <span class="text-xs bg-muted px-2 py-1 rounded">DEV</span>
+        </div>
+      </CardHeader>
+      <CardContent class="space-y-4">
+        <div
+          v-for="flag in featureFlags"
+          :key="flag.code"
+          class="flex items-center justify-between"
+        >
+          <div class="flex-1">
+            <label :for="flag.code" class="text-sm font-medium cursor-pointer">
+              {{ flag.name }}
+            </label>
+            <div class="text-xs text-muted-foreground">{{ flag.code }}</div>
+          </div>
+          <Switch
+            :id="flag.code"
+            :model-value="flag.enabled"
+            @update:model-value="toggleFeatureFlag(flag.code)"
+          />
+        </div>
+      </CardContent>
+    </Card>
+
+    <Button @click="isExpanded = !isExpanded" size="icon" class="h-12 w-12 rounded-full">
+      {{ isExpanded ? '×' : '+' }}
+    </Button>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+import { useFeatureFlagsStore } from '@/stores/featureFlags'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Switch } from '@/components/ui/switch'
+import { Button } from '@/components/ui/button'
+
+const featureFlagsStore = useFeatureFlagsStore()
+const { featureFlags, isDevelopment, toggleFeatureFlag } = featureFlagsStore
+
+const isExpanded = ref(false)
+</script>

--- a/view/src/components/ui/switch/Switch.vue
+++ b/view/src/components/ui/switch/Switch.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import type { SwitchRootEmits, SwitchRootProps } from 'reka-ui'
+import type { HTMLAttributes } from 'vue'
+import { reactiveOmit } from '@vueuse/core'
+import { SwitchRoot, SwitchThumb, useForwardPropsEmits } from 'reka-ui'
+import { cn } from '@/lib/utils'
+
+const props = defineProps<SwitchRootProps & { class?: HTMLAttributes['class'] }>()
+
+const emits = defineEmits<SwitchRootEmits>()
+
+const delegatedProps = reactiveOmit(props, 'class')
+
+const forwarded = useForwardPropsEmits(delegatedProps, emits)
+</script>
+
+<template>
+  <SwitchRoot
+    data-slot="switch"
+    v-bind="forwarded"
+    :class="
+      cn(
+        'peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+        props.class
+      )
+    "
+  >
+    <SwitchThumb
+      data-slot="switch-thumb"
+      :class="
+        cn(
+          'bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0'
+        )
+      "
+    >
+      <slot name="thumb" />
+    </SwitchThumb>
+  </SwitchRoot>
+</template>

--- a/view/src/components/ui/switch/index.ts
+++ b/view/src/components/ui/switch/index.ts
@@ -1,0 +1,1 @@
+export { default as Switch } from './Switch.vue'

--- a/view/src/stores/featureFlags.ts
+++ b/view/src/stores/featureFlags.ts
@@ -1,0 +1,85 @@
+import { ref, computed } from 'vue'
+import { defineStore } from 'pinia'
+import type { FeatureFlag, FeatureFlagConfig } from '@/types/featureFlags'
+
+const STORAGE_KEY = 'myriade-feature-flags'
+
+const DEFAULT_FEATURE_FLAGS: FeatureFlag[] = [
+  {
+    name: 'Catalog',
+    code: 'catalog',
+    enabled: false
+  }
+]
+
+export const useFeatureFlagsStore = defineStore('featureFlags', () => {
+  const featureFlags = ref<FeatureFlag[]>([])
+
+  const loadFeatureFlags = () => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY)
+      if (stored) {
+        const parsedFlags = JSON.parse(stored) as FeatureFlag[]
+
+        // Merge with defaults to handle new flags
+        const mergedFlags = DEFAULT_FEATURE_FLAGS.map((defaultFlag) => {
+          const storedFlag = parsedFlags.find((f) => f.code === defaultFlag.code)
+          return storedFlag || defaultFlag
+        })
+
+        featureFlags.value = mergedFlags
+      } else {
+        featureFlags.value = [...DEFAULT_FEATURE_FLAGS]
+      }
+    } catch (error) {
+      console.error('Failed to load feature flags:', error)
+      featureFlags.value = [...DEFAULT_FEATURE_FLAGS]
+    }
+  }
+
+  const saveFeatureFlags = () => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(featureFlags.value))
+    } catch (error) {
+      console.error('Failed to save feature flags:', error)
+    }
+  }
+
+  const toggleFeatureFlag = (code: string) => {
+    const flag = featureFlags.value.find((f) => f.code === code)
+    if (flag) {
+      flag.enabled = !flag.enabled
+      saveFeatureFlags()
+    }
+  }
+
+  // Check if a feature is enabled
+  const isFeatureEnabled = (config: FeatureFlagConfig): boolean => {
+    // Only enable feature flags in development and staging modes
+    const mode = import.meta.env.MODE
+    if (mode === 'production') {
+      return false
+    }
+
+    const code = typeof config === 'string' ? config : config.code
+    const flag = featureFlags.value.find((f) => f.code === code)
+    return flag?.enabled || false
+  }
+
+  const isDevelopment = computed(() => {
+    const mode = import.meta.env.MODE
+    return mode === 'development' || mode === 'staging'
+  })
+
+  // Initialize store
+  loadFeatureFlags()
+
+  return {
+    featureFlags,
+    isDevelopment,
+    toggleFeatureFlag,
+    isFeatureEnabled,
+    loadFeatureFlags,
+    saveFeatureFlags
+  }
+})

--- a/view/src/types/featureFlags.ts
+++ b/view/src/types/featureFlags.ts
@@ -1,0 +1,11 @@
+export interface FeatureFlag {
+  name: string
+  code: string
+  enabled: boolean
+}
+
+export type FeatureFlagCode = string
+export type FeatureFlagConfig = FeatureFlag | FeatureFlagCode
+
+// Vite modes for feature flag environments
+export type ViteMode = 'development' | 'staging' | 'production'

--- a/view/src/utils/featureFlags.ts
+++ b/view/src/utils/featureFlags.ts
@@ -1,0 +1,27 @@
+import { useFeatureFlagsStore } from '@/stores/featureFlags'
+import type { FeatureFlagConfig } from '@/types/featureFlags'
+
+/**
+ * Check if a feature flag is enabled
+ * @param config - Either a feature flag code (string) or a FeatureFlag object
+ * @returns boolean - true if feature is enabled, false otherwise
+ *
+ * @example
+ * // Using feature code
+ * if (isFeatureEnabled('new-chat-ui')) {
+ *   // Show new chat UI
+ * }
+ *
+ * // Using feature config object
+ * const feature = { name: 'Beta Features', code: 'beta-features', enabled: true }
+ * if (isFeatureEnabled(feature)) {
+ *   // Show beta features
+ * }
+ */
+export function isFeatureEnabled(config: FeatureFlagConfig): boolean {
+  const featureFlagsStore = useFeatureFlagsStore()
+  return featureFlagsStore.isFeatureEnabled(config)
+}
+
+export { useFeatureFlagsStore } from '@/stores/featureFlags'
+export type { FeatureFlag, FeatureFlagConfig, FeatureFlagCode } from '@/types/featureFlags'

--- a/view/src/vite-env.d.ts
+++ b/view/src/vite-env.d.ts
@@ -1,0 +1,11 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_SOCKET_URL: string
+  readonly VITE_SENTRY_ENABLED: string
+  readonly VITE_SENTRY_DSN?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}


### PR DESCRIPTION
Petit feature flipping, pour nous permettre de cacher catalog ou autre si on le souhaite,.

1. basé côté front
2. Pas de changement au workflow de défaut qui va toujours build en mode `production` et n'aura pas le bouton de visible
3. Pour fly.io je passe en args `staging` pour qu'on l'ai sur les previews de déploiement 



https://github.com/user-attachments/assets/b6e6ed82-1042-4d62-aa4e-4089a9a623cb





