### PR TITLE
Add catalog parsing trigger and validation flags

### DIFF
--- a/service/chat/tools/catalog.py
+++ b/service/chat/tools/catalog.py
@@ -334,6 +334,7 @@ class CatalogTool:
         if not updates:
             return f"No updates provided for asset '{asset.name}'"
 
+        asset.validated = False
         self.session.flush()
 
         return yaml.dump(
@@ -412,6 +413,7 @@ class CatalogTool:
             if not updates:
                 return f"No updates needed for term '{name}'"
 
+            existing_term.validated = False
             self.session.flush()
 
             result = {

--- a/service/migrations/versions/d8d74b96c4b2_add_validated_flag_to_catalog_models.py
+++ b/service/migrations/versions/d8d74b96c4b2_add_validated_flag_to_catalog_models.py
@@ -1,0 +1,48 @@
+"""add validated flag to catalog models
+
+Revision ID: d8d74b96c4b2
+Revises: c3dae8db7eae
+Create Date: 2025-10-08 00:00:00.000000
+
+"""
+
+from typing import Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d8d74b96c4b2"
+down_revision: Union[str, None] = "c3dae8db7eae"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    default_expr = sa.text("0") if bind.dialect.name == "sqlite" else sa.text("false")
+
+    op.add_column(
+        "asset",
+        sa.Column(
+            "validated",
+            sa.Boolean(),
+            nullable=False,
+            server_default=default_expr,
+        ),
+    )
+    op.add_column(
+        "term",
+        sa.Column(
+            "validated",
+            sa.Boolean(),
+            nullable=False,
+            server_default=default_expr,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("term", "validated")
+    op.drop_column("asset", "validated")
+

--- a/service/models/catalog.py
+++ b/service/models/catalog.py
@@ -2,8 +2,9 @@ import uuid
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, List, Optional
 
-from sqlalchemy import ForeignKey, String, Text, UniqueConstraint
+from sqlalchemy import Boolean, ForeignKey, String, Text, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.sql import expression
 
 from db import JSONB, UUID, Base, DefaultBase, SerializerMixin
 
@@ -29,6 +30,12 @@ class Asset(SerializerMixin, DefaultBase, Base):
     # Metadata fields
     tags: Mapped[Optional[List[str]]] = mapped_column(JSONB)
     created_by: Mapped[Optional[str]] = mapped_column(String, ForeignKey("user.id"))
+    validated: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        default=False,
+        server_default=expression.false(),
+    )
 
     # 1:1 optional facets
     table_facet: Mapped[Optional["TableFacet"]] = relationship(
@@ -110,6 +117,12 @@ class Term(SerializerMixin, DefaultBase, Base):
     )
     synonyms: Mapped[Optional[List[str]]] = mapped_column(JSONB)
     business_domains: Mapped[Optional[List[str]]] = mapped_column(JSONB)
+    validated: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        default=False,
+        server_default=expression.false(),
+    )
 
     # Relationships
     database: Mapped["Database"] = relationship("Database")

--- a/view/src/components/ContextSelection.vue
+++ b/view/src/components/ContextSelection.vue
@@ -44,7 +44,6 @@ import {
 import { useContextsStore } from '@/stores/contexts'
 import { useDatabasesStore } from '@/stores/databases'
 
-import { onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 
 const router = useRouter()

--- a/view/src/views/CatalogPage.vue
+++ b/view/src/views/CatalogPage.vue
@@ -10,7 +10,39 @@
             {{ catalogStore.termsArray.length }} terms
           </p>
         </div>
-        <Button @click="refresh"> Refresh </Button>
+        <div class="flex items-center space-x-3">
+          <Button
+            variant="outline"
+            @click="runCatalogParse"
+            :disabled="!contextsStore.contextSelected || parsingCatalog"
+          >
+            <span class="flex items-center">
+              <svg
+                v-if="parsingCatalog"
+                class="animate-spin -ml-1 mr-2 h-4 w-4 text-primary-600"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+              >
+                <circle
+                  class="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  stroke-width="4"
+                />
+                <path
+                  class="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                />
+              </svg>
+              <span>{{ parsingCatalog ? 'Parsing…' : 'Fill Catalog' }}</span>
+            </span>
+          </Button>
+          <Button @click="refresh" :disabled="parsingCatalog"> Refresh </Button>
+        </div>
       </div>
     </div>
 
@@ -182,11 +214,33 @@ const newTerm = ref({
 // Computed
 const loading = computed(() => catalogStore.loading)
 const error = computed(() => catalogStore.error)
+const parsingCatalog = computed(() => catalogStore.parsing)
 
 // Methods
-function refresh() {
-  if (contextsStore.contextSelected) {
-    catalogStore.fetchTerms(contextsStore.contextSelected.id)
+async function refresh() {
+  if (!contextsStore.contextSelected) {
+    return
+  }
+
+  try {
+    await Promise.all([
+      catalogStore.fetchTerms(contextsStore.contextSelected.id),
+      catalogStore.fetchAssets(contextsStore.contextSelected.id, undefined)
+    ])
+  } catch (error) {
+    console.error('Error refreshing catalog:', error)
+  }
+}
+
+async function runCatalogParse() {
+  if (!contextsStore.contextSelected) {
+    return
+  }
+
+  try {
+    await catalogStore.parseCatalog(contextsStore.contextSelected.id)
+  } catch (error) {
+    console.error('Error starting catalog parsing:', error)
   }
 }
 


### PR DESCRIPTION
## Summary
- add a validated flag to catalog assets and terms plus a migration to backfill defaults
- expose a backend route that launches the analyst agent to repopulate the catalog
- surface a "Fill Catalog" action in the UI and update catalog store types/logic, including lint cleanup

## Testing
- uv run ruff check *(fails: unable to fetch psycopg2-binary due to network restrictions)*
- uv run pytest -q *(fails: unable to fetch psycopg2-binary due to network restrictions)*
- yarn lint

------
https://chatgpt.com/codex/tasks/task_b_68d3a29194508328994d674230e91e6e