### PR TITLE
feat: add confirmation on update asset inside chat

### DIFF
--- a/service/chat/analyst_agent.py
+++ b/service/chat/analyst_agent.py
@@ -16,7 +16,6 @@ from chat.proxy_provider import ProxyProvider
 from chat.tools.catalog import CatalogTool
 from chat.tools.database import DatabaseTool
 from chat.tools.echarts import EchartsTool
-from chat.tools.quality import SemanticCatalog
 from chat.tools.workspace import WorkspaceTool
 from chat.utils import parse_answer_text
 from models import Chart, Conversation, ConversationMessage, Query
@@ -115,10 +114,6 @@ class DataAnalystAgent:
             EchartsTool(self.session, self.conversation.database),
             "echarts",
         )
-        semantic_catalog = SemanticCatalog(
-            self.session, self.conversation.id, self.conversation.databaseId
-        )
-        self.agent.add_tool(semantic_catalog, "semantic_catalog")
         catalog_tool = CatalogTool(self.session, self.conversation.database)
         self.agent.add_tool(catalog_tool, "catalog")
         if (

--- a/service/migrations/versions/0f8a4c77fd2f_add_reviewed_flags.py
+++ b/service/migrations/versions/0f8a4c77fd2f_add_reviewed_flags.py
@@ -1,0 +1,40 @@
+"""add reviewed flags to catalog entities
+
+Revision ID: 0f8a4c77fd2f
+Revises: c3dae8db7eae
+Create Date: 2025-03-06 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0f8a4c77fd2f"
+down_revision: Union[str, None] = "c3dae8db7eae"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "asset",
+        sa.Column("reviewed", sa.Boolean(), nullable=False, server_default=sa.true()),
+    )
+    op.add_column(
+        "term",
+        sa.Column("reviewed", sa.Boolean(), nullable=False, server_default=sa.true()),
+    )
+
+    bind = op.get_bind()
+    # SQLite does not support ALTER TABLE ... DROP DEFAULT, so skip there.
+    if bind.dialect.name != "sqlite":
+        op.alter_column("asset", "reviewed", server_default=None)
+        op.alter_column("term", "reviewed", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column("term", "reviewed")
+    op.drop_column("asset", "reviewed")

--- a/service/models/catalog.py
+++ b/service/models/catalog.py
@@ -19,6 +19,7 @@ class Asset(SerializerMixin, DefaultBase, Base):
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(), primary_key=True, default=uuid.uuid4)
     urn: Mapped[str] = mapped_column(String, unique=True, nullable=False)
+    reviewed: Mapped[bool] = mapped_column(default=False, nullable=False)
     type: Mapped[str] = mapped_column(String, nullable=False)  # "TABLE", "COLUMN"
     name: Mapped[Optional[str]] = mapped_column(String)
     description: Mapped[Optional[str]] = mapped_column(Text)
@@ -103,6 +104,7 @@ class Term(SerializerMixin, DefaultBase, Base):
     __tablename__ = "term"
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(), primary_key=True, default=uuid.uuid4)
+    reviewed: Mapped[bool] = mapped_column(default=False, nullable=False)
     name: Mapped[str] = mapped_column(String, nullable=False)
     definition: Mapped[str] = mapped_column(Text, nullable=False)
     database_id: Mapped[uuid.UUID] = mapped_column(
@@ -127,4 +129,5 @@ class Term(SerializerMixin, DefaultBase, Base):
             "definition": definition,
             "synonyms": self.synonyms,
             "business_domains": self.business_domains,
+            "reviewed": self.reviewed,
         }

--- a/view/src/components/AskCatalogConfirmation.vue
+++ b/view/src/components/AskCatalogConfirmation.vue
@@ -1,0 +1,427 @@
+<template>
+  <div class="bg-yellow-50 border border-yellow-200 rounded-lg p-4 my-3">
+    <div class="flex items-start gap-3">
+      <component :is="statusIcon" class="w-5 h-5 mt-0.5 flex-shrink-0" :class="statusIconClass" />
+
+      <div class="flex-1 text-sm">
+        <h4 class="text-sm font-medium text-yellow-800 mb-2">
+          {{ proposal.title || 'Catalog Operation Confirmation Required' }}
+        </h4>
+
+        <p v-if="showAutoAppliedMessage" class="text-yellow-700 mb-3">
+          These changes were applied automatically by AI. Approve to mark them as human-reviewed.
+        </p>
+
+        <p v-else-if="showPendingMessage" class="text-yellow-700 mb-3">
+          This operation will update your data catalog. Review the proposed changes before
+          approving.
+        </p>
+
+        <p v-else-if="isApproved" class="text-green-700 mb-3">
+          Operation approved and marked as reviewed.
+        </p>
+
+        <p v-else-if="isRejected" class="text-red-700 mb-3">
+          Operation rejected. No catalog changes were made.
+        </p>
+
+        <div v-if="assetMetadata" class="mb-4 space-y-1 text-yellow-700">
+          <div>
+            <span class="font-semibold text-yellow-800">Asset:</span> {{ assetMetadata.name }}
+          </div>
+          <div v-if="assetMetadata.type">
+            <span class="font-semibold text-yellow-800">Type:</span> {{ assetMetadata.type }}
+          </div>
+        </div>
+
+        <div v-else-if="termMetadata" class="mb-4 space-y-1 text-yellow-700">
+          <div>
+            <span class="font-semibold text-yellow-800">Term:</span> {{ termMetadata.name }}
+          </div>
+        </div>
+
+        <div v-if="entityType === 'asset'" class="space-y-4">
+          <div>
+            <label class="font-semibold text-yellow-800 block mb-1">Description</label>
+            <p class="text-xs text-gray-500 mb-2">
+              Current: <span class="text-gray-700">{{ currentDescriptionDisplay }}</span>
+            </p>
+            <Textarea
+              class="bg-white"
+              v-model="assetDescriptionModel"
+              :disabled="!isEditable"
+              rows="4"
+            />
+          </div>
+
+          <div>
+            <label class="font-semibold text-yellow-800 block mb-1">Tags</label>
+            <p class="text-xs text-gray-500 mb-2">
+              Current: <span class="text-gray-700">{{ currentTagsDisplay }}</span>
+            </p>
+            <TagsInput
+              v-model="assetTagsModel"
+              :disabled="!isEditable"
+              :class="!isEditable ? 'opacity-50' : ''"
+            >
+              <TagsInputItem v-for="tag in assetTagsModel" :key="tag" :value="tag">
+                <TagsInputItemText />
+                <TagsInputItemDelete v-if="isEditable" />
+              </TagsInputItem>
+              <TagsInputInput v-if="isEditable" placeholder="Add tag" />
+            </TagsInput>
+          </div>
+        </div>
+
+        <div v-else-if="entityType === 'term'" class="space-y-4">
+          <div>
+            <label class="font-semibold text-yellow-800 block mb-1">Definition</label>
+            <p class="text-xs text-gray-500 mb-2">
+              Current: <span class="text-gray-700">{{ currentDefinitionDisplay }}</span>
+            </p>
+            <Textarea
+              class="bg-white"
+              v-model="termDefinitionModel"
+              :disabled="!isEditable"
+              rows="4"
+            />
+          </div>
+
+          <div>
+            <label class="font-semibold text-yellow-800 block mb-1">Synonyms</label>
+            <p class="text-xs text-gray-500 mb-2">
+              Current: <span class="text-gray-700">{{ currentSynonymsDisplay }}</span>
+            </p>
+            <TagsInput
+              v-model="termSynonymsModel"
+              :disabled="!isEditable"
+              :class="!isEditable ? 'opacity-50' : ''"
+            >
+              <TagsInputItem v-for="synonym in termSynonymsModel" :key="synonym" :value="synonym">
+                <TagsInputItemText />
+                <TagsInputItemDelete v-if="isEditable" />
+              </TagsInputItem>
+              <TagsInputInput v-if="isEditable" placeholder="Add synonym" />
+            </TagsInput>
+          </div>
+
+          <div>
+            <label class="font-semibold text-yellow-800 block mb-1">Business Domains</label>
+            <p class="text-xs text-gray-500 mb-2">
+              Current: <span class="text-gray-700">{{ currentBusinessDomainsDisplay }}</span>
+            </p>
+            <TagsInput
+              v-model="termBusinessDomainsModel"
+              :disabled="!isEditable"
+              :class="!isEditable ? 'opacity-50' : ''"
+            >
+              <TagsInputItem
+                v-for="domain in termBusinessDomainsModel"
+                :key="domain"
+                :value="domain"
+              >
+                <TagsInputItemText />
+                <TagsInputItemDelete v-if="isEditable" />
+              </TagsInputItem>
+              <TagsInputInput v-if="isEditable" placeholder="Add domain" />
+            </TagsInput>
+          </div>
+        </div>
+
+        <div class="flex gap-2 mt-3" v-if="isEditable">
+          <Button
+            variant="default"
+            @click="handleApprove"
+            :disabled="isProcessing"
+            :is-loading="isProcessing"
+          >
+            <template #loading>Executing...</template>
+            Approve
+          </Button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import Button from '@/components/ui/button/Button.vue'
+import {
+  TagsInput,
+  TagsInputInput,
+  TagsInputItem,
+  TagsInputItemDelete,
+  TagsInputItemText
+} from '@/components/ui/tags-input'
+import Textarea from '@/components/ui/textarea/Textarea.vue'
+import { socket } from '@/plugins/socket'
+import { CheckCircleIcon, ExclamationTriangleIcon, XCircleIcon } from '@heroicons/vue/24/outline'
+import { computed, ref, watch } from 'vue'
+import { useRoute } from 'vue-router'
+
+const props = defineProps<{
+  proposal: Record<string, any>
+  functionCallId: string | undefined
+}>()
+
+const route = useRoute()
+const conversationId = computed(() =>
+  route.params.id === 'new' ? null : (route.params.id as string)
+)
+
+const isProcessing = ref(false)
+
+const status = computed(() => props.proposal?.status ?? 'pending_review')
+const isRejected = computed(() => status.value === 'rejected')
+const showAutoAppliedMessage = computed(() => status.value === 'pending_review')
+const showPendingMessage = computed(() => status.value === 'pending')
+const isEditable = computed(() => showAutoAppliedMessage.value || showPendingMessage.value)
+const isApproved = computed(() => !isEditable.value && !isRejected.value)
+
+const statusIcon = computed(() => {
+  if (isApproved.value) return CheckCircleIcon
+  if (isRejected.value) return XCircleIcon
+  return ExclamationTriangleIcon
+})
+
+const statusIconClass = computed(() => {
+  if (isApproved.value) return 'text-green-500'
+  if (isRejected.value) return 'text-red-500'
+  return 'text-yellow-400'
+})
+
+const entity = computed<Record<string, any>>(() => {
+  const raw = props.proposal?.entity
+  return raw && typeof raw === 'object' ? (raw as Record<string, any>) : {}
+})
+
+const entityType = computed(() => (entity.value?.type as string | undefined) ?? '')
+
+const currentState = computed<Record<string, unknown>>(() => {
+  const current = props.proposal?.current
+  if (current && typeof current === 'object') {
+    return current as Record<string, unknown>
+  }
+  return {}
+})
+
+const localProposed = ref<Record<string, unknown>>({})
+
+const ensureStringArray = (value: unknown): string[] => {
+  if (!Array.isArray(value)) return []
+  return value
+    .map((item) => (typeof item === 'string' ? item.trim() : String(item ?? '')))
+    .filter((item) => item.length > 0)
+}
+
+const normalizeStringArray = (value: string[]): string[] => {
+  const seen = new Set<string>()
+  const result: string[] = []
+  value.forEach((item) => {
+    const trimmed = item.trim()
+    if (trimmed.length > 0 && !seen.has(trimmed)) {
+      seen.add(trimmed)
+      result.push(trimmed)
+    }
+  })
+  return result
+}
+
+const initializeLocalProposed = () => {
+  const proposedRaw = props.proposal?.proposed
+  let base: Record<string, unknown>
+  if (proposedRaw && typeof proposedRaw === 'object') {
+    base = proposedRaw
+  } else {
+    base = {}
+  }
+
+  if (entityType.value === 'asset') {
+    if (typeof base.description !== 'string') {
+      base.description =
+        typeof currentState.value.description === 'string'
+          ? (currentState.value.description as string)
+          : ''
+    }
+    base.tags = ensureStringArray(base.tags ?? currentState.value.tags)
+  } else if (entityType.value === 'term') {
+    if (typeof base.definition !== 'string') {
+      base.definition =
+        typeof currentState.value.definition === 'string'
+          ? (currentState.value.definition as string)
+          : ''
+    }
+    base.synonyms = ensureStringArray(base.synonyms ?? currentState.value.synonyms)
+    base.business_domains = ensureStringArray(
+      base.business_domains ?? currentState.value.business_domains
+    )
+    if (typeof base.name !== 'string' && typeof entity.value?.name === 'string') {
+      base.name = entity.value.name
+    }
+  }
+
+  localProposed.value = base
+}
+
+watch(
+  () => props.proposal,
+  () => {
+    initializeLocalProposed()
+  },
+  { immediate: true }
+)
+
+const assetDescriptionModel = computed({
+  get: () =>
+    typeof localProposed.value.description === 'string'
+      ? (localProposed.value.description as string)
+      : '',
+  set: (val: string) => {
+    localProposed.value = {
+      ...localProposed.value,
+      description: val
+    }
+  }
+})
+
+const assetTagsModel = computed<string[]>({
+  get: () => ensureStringArray(localProposed.value.tags),
+  set: (val: string[]) => {
+    localProposed.value = {
+      ...localProposed.value,
+      tags: normalizeStringArray(val)
+    }
+  }
+})
+
+const termDefinitionModel = computed({
+  get: () =>
+    typeof localProposed.value.definition === 'string'
+      ? (localProposed.value.definition as string)
+      : '',
+  set: (val: string) => {
+    localProposed.value = {
+      ...localProposed.value,
+      definition: val
+    }
+  }
+})
+
+const termSynonymsModel = computed<string[]>({
+  get: () => ensureStringArray(localProposed.value.synonyms),
+  set: (val: string[]) => {
+    localProposed.value = {
+      ...localProposed.value,
+      synonyms: normalizeStringArray(val)
+    }
+  }
+})
+
+const termBusinessDomainsModel = computed<string[]>({
+  get: () => ensureStringArray(localProposed.value.business_domains),
+  set: (val: string[]) => {
+    localProposed.value = {
+      ...localProposed.value,
+      business_domains: normalizeStringArray(val)
+    }
+  }
+})
+
+const emptyValueDisplay = ' X'
+
+const formatDisplay = (value: unknown): string => {
+  if (value === null || value === undefined) return emptyValueDisplay
+  if (Array.isArray(value)) {
+    if (value.length === 0) return emptyValueDisplay
+    return value.map((item) => String(item)).join(', ')
+  }
+  if (typeof value === 'string') {
+    return value.trim().length > 0 ? value : emptyValueDisplay
+  }
+  if (typeof value === 'object') {
+    return JSON.stringify(value)
+  }
+  return String(value)
+}
+
+const currentDescriptionDisplay = computed(() => formatDisplay(currentState.value?.description))
+
+const currentTagsDisplay = computed(
+  () => ensureStringArray(currentState.value?.tags).join(', ') || emptyValueDisplay
+)
+
+const currentDefinitionDisplay = computed(() => formatDisplay(currentState.value?.definition))
+
+const currentSynonymsDisplay = computed(
+  () => ensureStringArray(currentState.value?.synonyms).join(', ') || emptyValueDisplay
+)
+
+const currentBusinessDomainsDisplay = computed(
+  () => ensureStringArray(currentState.value?.business_domains).join(', ') || emptyValueDisplay
+)
+
+const buildProposedPayload = () => {
+  const payload = localProposed.value ?? ({} as Record<string, unknown>)
+
+  if (entityType.value === 'asset') {
+    payload.description = assetDescriptionModel.value.trim()
+    payload.tags = normalizeStringArray(assetTagsModel.value)
+  } else if (entityType.value === 'term') {
+    payload.definition = termDefinitionModel.value.trim()
+    payload.synonyms = normalizeStringArray(termSynonymsModel.value)
+    payload.business_domains = normalizeStringArray(termBusinessDomainsModel.value)
+    if (typeof payload.name !== 'string' && typeof entity.value?.name === 'string') {
+      payload.name = entity.value.name
+    }
+  }
+
+  localProposed.value = {
+    ...localProposed.value,
+    ...payload
+  }
+
+  return payload
+}
+
+const assetMetadata = computed(() => {
+  if (entityType.value !== 'asset') return null
+  return {
+    name:
+      (typeof entity.value?.name === 'string' && entity.value.name) ||
+      (typeof localProposed.value.name === 'string' ? (localProposed.value.name as string) : ''),
+    urn: entity.value?.urn as string | undefined,
+    type: entity.value?.type as string | undefined
+  }
+})
+
+const termMetadata = computed(() => {
+  if (entityType.value !== 'term') return null
+  const proposedName =
+    typeof localProposed.value.name === 'string'
+      ? (localProposed.value.name as string)
+      : typeof entity.value?.name === 'string'
+        ? entity.value.name
+        : ''
+  return {
+    name: proposedName
+  }
+})
+
+const handleApprove = async () => {
+  if (!conversationId.value || !props.functionCallId) return
+  try {
+    isProcessing.value = true
+    const proposedPayload = isEditable.value ? buildProposedPayload() : undefined
+    socket.emit(
+      'confirmCatalogOperation',
+      conversationId.value,
+      props.functionCallId,
+      proposedPayload
+    )
+  } catch (error) {
+    console.error('Failed to approve catalog entry:', error)
+  } finally {
+    isProcessing.value = false
+  }
+}
+</script>

--- a/view/src/components/Chat.vue
+++ b/view/src/components/Chat.vue
@@ -321,10 +321,23 @@ const isPublicMessage = (message: Message, index: number) => {
   const isFunctionAfterAnswer = isFunction && prevMessage?.isAnswer
   const isAnwser = message.isAnswer
   let hasWriteOperation = false
+  const functionCallArgs = (message.functionCall as { arguments?: unknown } | undefined)?.arguments
+  const hasCatalogProposal =
+    typeof functionCallArgs === 'object' &&
+    functionCallArgs !== null &&
+    'proposal' in functionCallArgs &&
+    Boolean((functionCallArgs as Record<string, unknown>).proposal)
   if (message.queryId) {
     hasWriteOperation = queriesStore.getQuery(message.queryId)?.operationType !== null
   }
-  return isUser || isFunctionAfterUser || isAnwser || isFunctionAfterAnswer || hasWriteOperation
+  return (
+    isUser ||
+    isFunctionAfterUser ||
+    isAnwser ||
+    isFunctionAfterAnswer ||
+    hasWriteOperation ||
+    hasCatalogProposal
+  )
 }
 
 /** END MESSAGE DISPLAY LOGIC **/

--- a/view/src/components/FunctionCallRenderer.vue
+++ b/view/src/components/FunctionCallRenderer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div v-if="!shouldHide">
     <div class="flex items-center gap-2 mb-2">
       <span class="text-lg">{{ displayInfo.icon }}</span>
       <b class="text-gray-700">{{ displayInfo.displayName }}</b>
@@ -39,7 +39,7 @@
 
     <!-- Default fallback renderer -->
     <div v-else>
-      <pre class="arguments">{{ functionCall.arguments }}</pre>
+      <pre class="arguments">{{ formattedArguments }}</pre>
     </div>
   </div>
 </template>
@@ -69,6 +69,49 @@ const props = defineProps<{
 
 // Compute display information for the function call
 const displayInfo = computed(() => getFunctionCallDisplayInfo(props.functionCall.name))
+
+const sanitizedArguments = computed(() => {
+  const args = props.functionCall.arguments
+  if (!args || typeof args !== 'object') {
+    return args
+  }
+
+  if ('proposal' in (args as Record<string, unknown>)) {
+    const { proposal, ...rest } = args as Record<string, unknown>
+    return rest
+  }
+
+  return args
+})
+
+const formattedArguments = computed(() => {
+  const args = sanitizedArguments.value
+  if (args === null || args === undefined) return ''
+  if (typeof args === 'string') return args
+  if (typeof args === 'number' || typeof args === 'boolean') return String(args)
+  try {
+    return JSON.stringify(args, null, 2)
+  } catch (e) {
+    console.error('Error formatting arguments:', e)
+    return String(args)
+  }
+})
+
+const shouldHide = computed(() => {
+  const name = props.functionCall.name
+  if (name === 'CatalogTool-catalog__update_asset' || name === 'CatalogTool-catalog__upsert_term') {
+    return true
+  }
+
+  const args = props.functionCall.arguments
+  if (typeof args === 'object' && args !== null && 'proposal' in args) {
+    const proposal = (args as Record<string, any>).proposal
+    const operation = proposal?.operation
+    return operation === 'update_asset' || operation === 'upsert_term'
+  }
+
+  return false
+})
 </script>
 
 <style scoped>

--- a/view/src/components/MessageDisplay.vue
+++ b/view/src/components/MessageDisplay.vue
@@ -100,6 +100,11 @@
             :status="queryData.status"
             @rejected="emit('rejected')"
           />
+          <AskCatalogConfirmation
+            v-if="catalogProposal && props.message.role === 'assistant'"
+            :proposal="catalogProposal"
+            :functionCallId="props.message.functionCallId"
+          />
         </div>
       </div>
 
@@ -177,6 +182,7 @@ import yaml from 'js-yaml'
 import { computed, defineEmits, defineProps, onMounted, ref } from 'vue'
 
 // Components
+import AskCatalogConfirmation from '@/components/AskCatalogConfirmation.vue'
 import AskQueryConfirmation from '@/components/AskQueryConfirmation.vue'
 import BaseEditor from '@/components/base/BaseEditor.vue'
 import BaseEditorPreview from '@/components/base/BaseEditorPreview.vue'
@@ -214,6 +220,10 @@ const editedContent = ref('')
 const queriesStore = useQueriesStore()
 const queryData = computed(() => queriesStore.getQuery(props.message.queryId))
 const needsConfirmation = computed(() => queriesStore.needsConfirmation(props.message.queryId))
+const catalogProposal = computed(() => {
+  const args = props.message.functionCall?.arguments as Record<string, any> | undefined
+  return args?.proposal ?? null
+})
 
 const toggleEditMode = () => {
   isEditing.value = !isEditing.value

--- a/view/src/components/ui/tags-input/TagsInput.vue
+++ b/view/src/components/ui/tags-input/TagsInput.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import type { TagsInputRootEmits, TagsInputRootProps } from 'reka-ui'
+import type { HTMLAttributes } from 'vue'
+import { reactiveOmit } from '@vueuse/core'
+import { TagsInputRoot, useForwardPropsEmits } from 'reka-ui'
+import { cn } from '@/lib/utils'
+
+const props = defineProps<TagsInputRootProps & { class?: HTMLAttributes['class'] }>()
+const emits = defineEmits<TagsInputRootEmits>()
+
+const delegatedProps = reactiveOmit(props, 'class')
+
+const forwarded = useForwardPropsEmits(delegatedProps, emits)
+</script>
+
+<template>
+  <TagsInputRoot
+    v-bind="forwarded"
+    :class="
+      cn(
+        'flex flex-wrap gap-2 items-center rounded-md border border-input bg-background px-3 py-1.5 text-sm',
+        props.class
+      )
+    "
+  >
+    <slot />
+  </TagsInputRoot>
+</template>

--- a/view/src/components/ui/tags-input/TagsInputInput.vue
+++ b/view/src/components/ui/tags-input/TagsInputInput.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import type { TagsInputInputProps } from 'reka-ui'
+import type { HTMLAttributes } from 'vue'
+import { reactiveOmit } from '@vueuse/core'
+import { TagsInputInput, useForwardProps } from 'reka-ui'
+import { cn } from '@/lib/utils'
+
+const props = defineProps<TagsInputInputProps & { class?: HTMLAttributes['class'] }>()
+
+const delegatedProps = reactiveOmit(props, 'class')
+
+const forwardedProps = useForwardProps(delegatedProps)
+</script>
+
+<template>
+  <TagsInputInput
+    v-bind="forwardedProps"
+    :class="
+      cn(
+        'text-sm min-h-5 focus:outline-none flex-1 bg-transparent px-1 ring-0 border-0 focus-visible:ring-offset-0 focus-visible:ring-0',
+        props.class
+      )
+    "
+  />
+</template>

--- a/view/src/components/ui/tags-input/TagsInputItem.vue
+++ b/view/src/components/ui/tags-input/TagsInputItem.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import type { TagsInputItemProps } from 'reka-ui'
+import type { HTMLAttributes } from 'vue'
+
+import { reactiveOmit } from '@vueuse/core'
+import { TagsInputItem, useForwardProps } from 'reka-ui'
+import { cn } from '@/lib/utils'
+
+const props = defineProps<TagsInputItemProps & { class?: HTMLAttributes['class'] }>()
+
+const delegatedProps = reactiveOmit(props, 'class')
+
+const forwardedProps = useForwardProps(delegatedProps)
+</script>
+
+<template>
+  <TagsInputItem
+    v-bind="forwardedProps"
+    :class="
+      cn(
+        'flex h-5 items-center rounded-md bg-secondary data-[state=active]:ring-ring data-[state=active]:ring-2 data-[state=active]:ring-offset-2 ring-offset-background',
+        props.class
+      )
+    "
+  >
+    <slot />
+  </TagsInputItem>
+</template>

--- a/view/src/components/ui/tags-input/TagsInputItemDelete.vue
+++ b/view/src/components/ui/tags-input/TagsInputItemDelete.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import type { TagsInputItemDeleteProps } from 'reka-ui'
+import type { HTMLAttributes } from 'vue'
+import { reactiveOmit } from '@vueuse/core'
+import { X } from 'lucide-vue-next'
+import { TagsInputItemDelete, useForwardProps } from 'reka-ui'
+import { cn } from '@/lib/utils'
+
+const props = defineProps<TagsInputItemDeleteProps & { class?: HTMLAttributes['class'] }>()
+
+const delegatedProps = reactiveOmit(props, 'class')
+
+const forwardedProps = useForwardProps(delegatedProps)
+</script>
+
+<template>
+  <TagsInputItemDelete
+    v-bind="forwardedProps"
+    :class="cn('flex rounded bg-transparent mr-1', props.class)"
+  >
+    <slot>
+      <X class="w-4 h-4" />
+    </slot>
+  </TagsInputItemDelete>
+</template>

--- a/view/src/components/ui/tags-input/TagsInputItemText.vue
+++ b/view/src/components/ui/tags-input/TagsInputItemText.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+import type { TagsInputItemTextProps } from 'reka-ui'
+import type { HTMLAttributes } from 'vue'
+import { reactiveOmit } from '@vueuse/core'
+import { TagsInputItemText, useForwardProps } from 'reka-ui'
+import { cn } from '@/lib/utils'
+
+const props = defineProps<TagsInputItemTextProps & { class?: HTMLAttributes['class'] }>()
+
+const delegatedProps = reactiveOmit(props, 'class')
+
+const forwardedProps = useForwardProps(delegatedProps)
+</script>
+
+<template>
+  <TagsInputItemText
+    v-bind="forwardedProps"
+    :class="cn('py-0.5 px-2 text-sm rounded bg-transparent', props.class)"
+  />
+</template>

--- a/view/src/components/ui/tags-input/index.ts
+++ b/view/src/components/ui/tags-input/index.ts
@@ -1,0 +1,5 @@
+export { default as TagsInput } from './TagsInput.vue'
+export { default as TagsInputInput } from './TagsInputInput.vue'
+export { default as TagsInputItem } from './TagsInputItem.vue'
+export { default as TagsInputItemDelete } from './TagsInputItemDelete.vue'
+export { default as TagsInputItemText } from './TagsInputItemText.vue'

--- a/view/src/stores/conversations.ts
+++ b/view/src/stores/conversations.ts
@@ -38,6 +38,7 @@ export interface Message {
     name: string
     arguments: any
   }
+  functionCallId?: string
   queryId?: string
   image?: string // base64 encoded image
 }


### PR DESCRIPTION
- Ajout d'une nouvelle colonne `reviewed` qui permet de savoir si la définition d'un asset a été validé ou non par un humain.
- Système d'approbation in chat
- Added TagSelect shadcn components
- Suppression du SemanticCatalog car parfois l'agent l'utilisait au lieu du nouveau tool catalog.


https://github.com/user-attachments/assets/fd3e49d0-f8e7-4a21-8ace-e6cdb63cfa21


<img width="779" height="474" alt="Capture d’écran 2025-09-24 à 16 21 34" src="https://github.com/user-attachments/assets/b72da820-3764-42a5-92a7-9727534c35a5" />

