### PR TITLE
feat: add explore database button on catalog page

### DIFF
--- a/view/src/components/PageHeader.vue
+++ b/view/src/components/PageHeader.vue
@@ -1,11 +1,14 @@
 <template>
   <header class="flex h-16 shrink-0 items-center gap-2 border-b px-4">
     <SidebarTrigger class="md:hidden -ml-1" />
-    <div class="flex gap-2 items-baseline">
+    <div class="flex gap-2 items-baseline flex-1">
       <h1 class="text-xl">{{ title }}</h1>
       <p v-if="subtitle" class="hidden md:block text-sm text-gray-500">
         {{ subtitle }}
       </p>
+    </div>
+    <div v-if="$slots.actions" class="flex items-center gap-2">
+      <slot name="actions" />
     </div>
   </header>
 </template>

--- a/view/src/views/CatalogPage.vue
+++ b/view/src/views/CatalogPage.vue
@@ -1,18 +1,18 @@
 <template>
   <div class="catalog-page flex flex-col h-full">
     <!-- Header -->
-    <div class="flex-none border-b border-gray-200 bg-white px-6 py-4">
-      <div class="flex items-center justify-between">
-        <div>
-          <h1 class="text-2xl font-semibold text-gray-900">Data Catalog</h1>
-          <p class="text-sm text-gray-600 mt-1">
-            {{ catalogStore.assetsArray.length }} assets •
-            {{ catalogStore.termsArray.length }} terms
-          </p>
-        </div>
+    <PageHeader
+      title="Data Catalog"
+      :subtitle="`${catalogStore.assetsArray.length} assets • ${catalogStore.termsArray.length} terms`"
+    >
+      <template #actions>
+        <Button @click="exploreDatabase" variant="outline" class="mr-2">
+          <SparklesIcon class="h-4 w-4 mr-2" />
+          Explore & Describe Assets
+        </Button>
         <Button @click="refresh"> Refresh </Button>
-      </div>
-    </div>
+      </template>
+    </PageHeader>
 
     <!-- Loading State -->
     <div v-if="loading" class="flex-1 flex items-center justify-center">
@@ -158,6 +158,7 @@
 <script setup lang="ts">
 import CatalogAssetsTable from '@/components/CatalogAssetsTable.vue'
 import LoaderIcon from '@/components/icons/LoaderIcon.vue'
+import PageHeader from '@/components/PageHeader.vue'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import Label from '@/components/ui/label/Label.vue'
@@ -165,10 +166,15 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs/'
 import { Textarea } from '@/components/ui/textarea'
 import { useCatalogStore } from '@/stores/catalog'
 import { useContextsStore } from '@/stores/contexts'
+import { useConversationsStore } from '@/stores/conversations'
 import { computed, onMounted, ref, watch } from 'vue'
+import { useRouter } from 'vue-router'
+import { SparklesIcon } from '@heroicons/vue/24/solid'
 
 const catalogStore = useCatalogStore()
 const contextsStore = useContextsStore()
+const conversationsStore = useConversationsStore()
+const router = useRouter()
 
 // State
 const showCreateTerm = ref(false)
@@ -187,6 +193,43 @@ const error = computed(() => catalogStore.error)
 function refresh() {
   if (contextsStore.contextSelected) {
     catalogStore.fetchTerms(contextsStore.contextSelected.id)
+  }
+}
+
+async function exploreDatabase() {
+  const prompt = `Explore the database and help fill in descriptions for the most important assets in our data catalog. Before writing any asset descriptions, please:
+
+1. **Perform a global business understanding check**:
+   - Analyze the overall database structure and schema
+   - Identify key business domains and data relationships
+   - Understand the primary business processes reflected in the data
+
+2. **Prioritize assets for description**:
+   - Identify core tables
+   - Consider tables with the most relationships or references
+
+3. **Write short and concise asset descriptions that include**:
+   - Key relationships with other tables
+   - Data freshness and update patterns if observable
+   - Important business rules or constraints
+
+Please start by exploring the database structure to understand our business context, then provide descriptions for the most important assets you identify. Focus on clarity and business value rather than technical implementation details.`
+
+  if (!contextsStore.contextSelected) {
+    console.error('No context selected')
+    return
+  }
+
+  try {
+    const newConversation = await conversationsStore.createConversation(
+      contextsStore.contextSelected.id
+    )
+
+    await conversationsStore.sendMessage(newConversation.id, prompt, 'text')
+
+    router.push({ name: 'ChatPage', params: { id: newConversation.id.toString() } })
+  } catch (error) {
+    console.error('Error creating conversation and sending message:', error)
   }
 }
 


### PR DESCRIPTION
Soucis en testant:
- Souvent il va s'arrêter lorsqu'il aura rempli par exemple une table. L'avantage est que de ce fait on a un résumé à la fin (mettre un "tout accepter" ici ?")
- Il s'arrêtera au pire une fois les `max_interactions` atteint

L'agent est assez intelligent pour aller chercher des stats + check les relations côté db:
<img width="759" height="580" alt="Capture d’écran 2025-09-24 à 16 47 15" src="https://github.com/user-attachments/assets/b0340bbf-5cc3-48a2-a45e-e2935edc06f6" />
<img width="786" height="327" alt="Capture d’écran 2025-09-24 à 16 46 39" src="https://github.com/user-attachments/assets/639c253f-800d-438a-b351-441d5d216834" />

En draft for now

### Vidéos
Après la demande:
https://github.com/user-attachments/assets/102c0820-f8e7-4b03-b3a1-071376648570

Avant:
https://github.com/user-attachments/assets/d15e2df7-e1e6-458f-8d05-e020b23846bb

