### PR TITLE
Improve credits left display

### DIFF
--- a/view/src/components/Chat.vue
+++ b/view/src/components/Chat.vue
@@ -142,14 +142,18 @@
               </div>
             </div>
           </transition>
-          <Card id="input-container" class="py-0 px-2">
-            <div
-              class="flex justify-end mb-2"
-              v-if="user?.credits !== undefined && user.credits < 50"
-            >
-              <!-- Credits Display (if user has less than 50 credits, show the number of credits left)-->
-              <div class="text-sm text-gray-500">{{ user.credits }} credits left</div>
+          
+          <!-- Credits Display - moved outside input container to prevent deformation -->
+          <div
+            class="flex justify-end mb-2 px-2"
+            v-if="user?.credits !== undefined && user.credits < 50"
+          >
+            <div class="text-xs text-gray-500 bg-gray-50 px-2 py-1 rounded-md">
+              {{ user.credits }} credits left
             </div>
+          </div>
+          
+          <Card id="input-container" class="py-0 px-2">
             <div class="flex items-center">
               <div class="w-full flex py-1">
                 <Textarea


### PR DESCRIPTION
Relocate and restyle the 'credits left' display to prevent input bar deformation and improve visual presentation.

---
Linear Issue: [DEV-380](https://linear.app/myriade/issue/DEV-380/improve-display-of-credits-left)

<a href="https://cursor.com/background-agent?bcId=bc-4e666305-2c06-4ff9-b54c-05641fdd313c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4e666305-2c06-4ff9-b54c-05641fdd313c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

