### PR TITLE
Fix chat input sticky to bottom

### DIFF
--- a/view/src/components/Chat.vue
+++ b/view/src/components/Chat.vue
@@ -1,14 +1,10 @@
 <template>
   <div>
     <PageHeader title="Chat" subtitle="Ask questions about your data and get instant answers." />
-    <div
-      ref="scrollContainer"
-      class="flex justify-center px-2 sm:px-4 lg:px-0"
-      v-touch:swipe.right="toggleSidebar"
-    >
-      <div class="flex flex-col w-full min-h-[calc(100vh-4rem)]">
-        <div class="flex flex-col flex-1 w-full max-w-3xl m-auto">
-          <div class="w-full lg:pt-4">
+    <div class="flex justify-center px-2 sm:px-4 lg:px-0" v-touch:swipe.right="toggleSidebar">
+      <div class="flex flex-col w-full h-[calc(100vh-4rem)]">
+        <div class="flex flex-col flex-1 w-full max-w-3xl m-auto overflow-hidden">
+          <div ref="scrollContainer" class="w-full lg:pt-4 flex-1 overflow-y-auto pb-4">
             <ul class="list-none">
               <template v-for="(group, index) in messageGroups" :key="index">
                 <li
@@ -109,7 +105,7 @@
 
         <div
           id="chat-input"
-          class="w-full max-w-4xl border-gray-300 bottom-0 sticky z-10 mx-auto lg:px-2 px-0 bg-white pb-4"
+          class="w-full max-w-4xl border-gray-300 bottom-0 sticky z-20 mx-auto lg:px-2 px-0 bg-white pb-4 pt-2 border-t border-gray-100 shadow-lg"
         >
           <transition
             enter-active-class="transition-all duration-300 ease-out"


### PR DESCRIPTION
Fix chat input not sticking to the bottom and overlapping with messages.

The chat input was not properly positioned due to incorrect container height calculation and missing overflow handling for the messages area. This PR ensures the main container uses a fixed height, makes the messages area scrollable, and enhances the sticky input's styling with a higher `z-index`, border, and shadow for proper visual separation and background coverage.

---
Linear Issue: [DEV-403](https://linear.app/myriade/issue/DEV-403/input-message-in-the-chat-is-not-sticky-to-the-bottom-and-underneath)

<a href="https://cursor.com/background-agent?bcId=bc-dbe179b4-9e79-4487-9f85-68edfbc26db4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dbe179b4-9e79-4487-9f85-68edfbc26db4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

