### PR TITLE
refactor: add info dbt tool

### DIFF
--- a/service/chat/tests/__snapshots__/test_functions.ambr
+++ b/service/chat/tests/__snapshots__/test_functions.ambr
@@ -1107,6 +1107,292 @@
       }),
     }),
     dict({
+      'description': 'Check if this DBT instance can refresh from repository.',
+      'name': 'DBT-dbt__can_refresh',
+      'parameters': dict({
+        'properties': dict({
+        }),
+        'title': 'Input for `can_refresh`',
+        'type': 'object',
+      }),
+    }),
+    dict({
+      'description': 'Create a folder if it does not exist.',
+      'name': 'DBT-dbt__create_folder_if_not_exists',
+      'parameters': dict({
+        'properties': dict({
+          'folder_path': dict({
+            'description': 'Relative path to the folder',
+            'title': 'Folder Path',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'folder_path',
+        ]),
+        'title': 'Input for `create_folder_if_not_exists`',
+        'type': 'object',
+      }),
+    }),
+    dict({
+      'description': 'Fetch all model details from the DBT catalog.',
+      'name': 'DBT-dbt__fetch_model',
+      'parameters': dict({
+        'properties': dict({
+          'key': dict({
+            'title': 'Key',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'key',
+        ]),
+        'title': 'Input for `fetch_model`',
+        'type': 'object',
+      }),
+    }),
+    dict({
+      'description': 'Return a list of models in the DBT catalog. Return: key, description',
+      'name': 'DBT-dbt__fetch_model_list',
+      'parameters': dict({
+        'properties': dict({
+        }),
+        'title': 'Input for `fetch_model_list`',
+        'type': 'object',
+      }),
+    }),
+    dict({
+      'description': 'Refresh catalog and manifest from repository if available. Returns True if refreshed successfully, False otherwise.',
+      'name': 'DBT-dbt__refresh_from_repository',
+      'parameters': dict({
+        'properties': dict({
+        }),
+        'title': 'Input for `refresh_from_repository`',
+        'type': 'object',
+      }),
+    }),
+    dict({
+      'description': 'Run a DBT command in the repository. This allows you to execute any dbt command like: - "run" - Run all models - "test" - Run all tests - "run --select model_name" - Run a specific model - "test --select model_name" - Test a specific model - "compile" - Compile all models - "build" - Run models and tests - "docs generate" - Generate documentation - "deps" - Install dependencies',
+      'name': 'DBT-dbt__run_dbt_command',
+      'parameters': dict({
+        'properties': dict({
+          'command': dict({
+            'description': "The DBT command to run (without 'dbt' prefix).",
+            'title': 'Command',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'command',
+        ]),
+        'title': 'Input for `run_dbt_command`',
+        'type': 'object',
+      }),
+    }),
+    dict({
+      'description': 'Search for a model in the DBT catalog. Return: key, description',
+      'name': 'DBT-dbt__search_models',
+      'parameters': dict({
+        'properties': dict({
+          'query': dict({
+            'title': 'Query',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'query',
+        ]),
+        'title': 'Input for `search_models`',
+        'type': 'object',
+      }),
+    }),
+    dict({
+      'description': 'Close all files',
+      'name': 'CodeEditor-code_editor__close_all_files',
+      'parameters': dict({
+        'properties': dict({
+        }),
+        'title': 'Input for `close_all_files`',
+        'type': 'object',
+      }),
+    }),
+    dict({
+      'description': 'Close a file when it is no longer needed (for lighter context usage)',
+      'name': 'CodeEditor-code_editor__close_file',
+      'parameters': dict({
+        'properties': dict({
+          'path': dict({
+            'title': 'Path',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'path',
+        ]),
+        'title': 'Input for `close_file`',
+        'type': 'object',
+      }),
+    }),
+    dict({
+      'description': 'Create a new file with the given content.',
+      'name': 'CodeEditor-code_editor__create_file',
+      'parameters': dict({
+        'properties': dict({
+          'content': dict({
+            'title': 'Content',
+            'type': 'string',
+          }),
+          'path': dict({
+            'title': 'Path',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'path',
+          'content',
+        ]),
+        'title': 'Input for `create_file`',
+        'type': 'object',
+      }),
+    }),
+    dict({
+      'description': 'Delete a file.',
+      'name': 'CodeEditor-code_editor__delete_file',
+      'parameters': dict({
+        'properties': dict({
+          'path': dict({
+            'title': 'Path',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'path',
+        ]),
+        'title': 'Input for `delete_file`',
+        'type': 'object',
+      }),
+    }),
+    dict({
+      'description': 'Display all the non-gitignored files in the directory.',
+      'name': 'CodeEditor-code_editor__display_directory',
+      'parameters': dict({
+        'properties': dict({
+        }),
+        'title': 'Input for `display_directory`',
+        'type': 'object',
+      }),
+    }),
+    dict({
+      'description': 'Delete a range of lines and insert text at the start line. Line numbers are 1-indexed. If the file is not open, it will be opened and kept open.',
+      'name': 'CodeEditor-code_editor__edit_file',
+      'parameters': dict({
+        'properties': dict({
+          'delete_lines_count': dict({
+            'description': 'The number of lines to delete.',
+            'title': 'Delete Lines Count',
+            'type': 'integer',
+          }),
+          'insert_text': dict({
+            'default': None,
+            'description': 'The text to insert at the start line.',
+            'title': 'Insert Text',
+            'type': 'string',
+          }),
+          'line_index_start': dict({
+            'description': 'The line number to start deleting from.',
+            'title': 'Line Index Start',
+            'type': 'integer',
+          }),
+          'path': dict({
+            'description': 'The path to the file to edit.',
+            'title': 'Path',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'path',
+          'line_index_start',
+          'delete_lines_count',
+        ]),
+        'title': 'Input for `edit_file`',
+        'type': 'object',
+      }),
+    }),
+    dict({
+      'description': None,
+      'name': 'CodeEditor-code_editor__read_file',
+      'parameters': dict({
+        'properties': dict({
+          'end_line': dict({
+            'default': None,
+            'title': 'End Line',
+            'type': 'integer',
+          }),
+          'path': dict({
+            'title': 'Path',
+            'type': 'string',
+          }),
+          'start_line': dict({
+            'default': 1,
+            'title': 'Start Line',
+            'type': 'integer',
+          }),
+        }),
+        'required': list([
+          'path',
+        ]),
+        'title': 'Input for `read_file`',
+        'type': 'object',
+      }),
+    }),
+    dict({
+      'description': "Search recursively for files containing 'search_text' and return results in VSCode format.",
+      'name': 'CodeEditor-code_editor__search_files',
+      'parameters': dict({
+        'properties': dict({
+          'search_text': dict({
+            'title': 'Search Text',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'search_text',
+        ]),
+        'title': 'Input for `search_files`',
+        'type': 'object',
+      }),
+    }),
+    dict({
+      'description': "Replace all occurrences of 'old_string' with 'new_string' in the file. If the file is not open, it will be opened and kept open.",
+      'name': 'CodeEditor-code_editor__str_replace',
+      'parameters': dict({
+        'properties': dict({
+          'new_string': dict({
+            'description': 'The new text to insert in place of the old text',
+            'title': 'New String',
+            'type': 'string',
+          }),
+          'old_string': dict({
+            'description': 'The text to replace (must match exactly, including whitespace and indentation)',
+            'title': 'Old String',
+            'type': 'string',
+          }),
+          'path': dict({
+            'description': 'The path to the file to edit.',
+            'title': 'Path',
+            'type': 'string',
+          }),
+        }),
+        'required': list([
+          'path',
+          'old_string',
+          'new_string',
+        ]),
+        'title': 'Input for `str_replace`',
+        'type': 'object',
+      }),
+    }),
+    dict({
       'description': None,
       'name': 'Notes-notes__close_note',
       'parameters': dict({

--- a/service/chat/tests/conftest.py
+++ b/service/chat/tests/conftest.py
@@ -90,11 +90,14 @@ def analyst_agent(session, conversation):
 @pytest.fixture
 def analyst_agent_dbt(session, conversation):
     """Create a data analyst agent instance with a database and project"""
+    # Set DBT configuration before creating the agent
+    conversation.database.dbt_repo_path = "test"
+    conversation.database.dbt_catalog = {"sources": {}, "nodes": {}}
+    conversation.database.dbt_manifest = {"sources": {}, "nodes": {}}
+    session.flush()  # Make sure changes are persisted
+    
     agent = DataAnalystAgent(
         session=session,
         conversation=conversation,
     )
-    agent.conversation.database.dbt_repo_path = "test"
-    agent.conversation.database.dbt_catalog = {"sources": {}, "nodes": {}}
-    agent.conversation.database.dbt_manifest = {"sources": {}, "nodes": {}}
     return agent

--- a/service/chat/tools/dbt.py
+++ b/service/chat/tools/dbt.py
@@ -122,9 +122,24 @@ class DBT:
         return bool(self.repo_path and self.database_config)
 
     def run_dbt_command(self, command: str):
-        """Run a DBT command.
+        """Run a DBT command in the repository.
+
+        This allows you to execute any dbt command like:
+        - "run" - Run all models
+        - "test" - Run all tests
+        - "run --select model_name" - Run a specific model
+        - "test --select model_name" - Test a specific model
+        - "compile" - Compile all models
+        - "build" - Run models and tests
+        - "docs generate" - Generate documentation
+        - "deps" - Install dependencies
+
         Args:
-            command: The DBT command to run. eg. "docs generate"
+            command: The DBT command to run (without 'dbt' prefix).
+                    Examples: "run", "test", "run --select my_model"
+
+        Returns:
+            Command output including success status, exit code, stdout and stderr
         """
         if not self.database_config:
             raise ValueError("Database configuration required to run DBT commands")


### PR DESCRIPTION
Add direct DBT command execution and convenience methods for agents, and update chat instructions and test setup.

The `analyst_agent_dbt` test fixture was incorrectly initializing the DBT tool by setting `dbt_repo_path` after agent creation, preventing the DBT tool from being added. This PR fixes the fixture to ensure proper initialization, allowing the agent to correctly access and utilize DBT commands and new convenience methods.

---
Linear Issue: [DEV-428](https://linear.app/myriade/issue/DEV-428/dbt-add-instruction-so-agent-run-dbt-commands-directly)

<a href="https://cursor.com/background-agent?bcId=bc-33e09fc4-b025-48d3-9824-7b6c93062991"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-33e09fc4-b025-48d3-9824-7b6c93062991"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

