### PR TITLE
Resolve issue selecting new connection

### DIFF
--- a/view/src/components/database/DatabaseForm.vue
+++ b/view/src/components/database/DatabaseForm.vue
@@ -154,6 +154,7 @@ import {
   type Database,
   type Engine
 } from '@/stores/databases'
+import { useContextsStore } from '@/stores/contexts'
 import { Form } from 'vee-validate'
 import { computed, onMounted, reactive, ref, watch } from 'vue'
 import ConnectionStatusAlert from './ConnectionStatusAlert.vue'
@@ -178,6 +179,7 @@ const emit = defineEmits<{
 
 // Stores
 const databasesStore = useDatabasesStore()
+const contextsStore = useContextsStore()
 
 // State
 const database = reactive<Database>(makeEmptyDatabase())
@@ -187,7 +189,6 @@ if (props.engine) {
 const isTestingConnection = ref(false)
 const isSaving = ref(false)
 const connectionStatus = ref<{ type: 'success' | 'error'; message: string } | null>(null)
-const isDbtSupportOpen = ref(false)
 
 // DBT-related state
 const isValidatingRepo = ref(false)
@@ -304,6 +305,8 @@ const handleSave = async () => {
       // Set as selected and refresh list for create mode
       databasesStore.setDatabaseSelected(result)
       await databasesStore.fetchDatabases({ refresh: true })
+      // Set the new database as the selected context
+      contextsStore.setSelectedContext(`database-${result.id}`)
     }
 
     emit('saved', result)
@@ -380,9 +383,6 @@ const generateDbtDocs = async () => {
   }
 }
 
-const toggleDbtSupport = () => {
-  isDbtSupportOpen.value = !isDbtSupportOpen.value
-}
 // Expose methods for parent components
 defineExpose({
   testConnection,


### PR DESCRIPTION
Automatically select the newly created database connection as the active context to improve user experience.

Previously, creating a new database only updated the database store, but the application's context system (which manages active projects/databases) was not updated. This PR ensures the new connection is immediately active, resolving DEV-406.

---
Linear Issue: [DEV-406](https://linear.app/myriade/issue/DEV-406/apres-avoir-cree-une-nouvelle-connexion-selectioner-en-context-la)

<a href="https://cursor.com/background-agent?bcId=bc-8a191ed6-5088-4f56-ad9a-ef68c84de4dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8a191ed6-5088-4f56-ad9a-ef68c84de4dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

