### PR TITLE
feat: show description for clicked selected elements inside explorer

### DIFF
--- a/view/src/components/DatabaseExplorer.vue
+++ b/view/src/components/DatabaseExplorer.vue
@@ -14,7 +14,7 @@
           :table="table"
           :showColumns="table.name == showTableKey"
           @click="onClick(table.name)"
-          @dblclick="onDblClick(table)"
+          @search="onSearch"
           :isUsed="true"
         />
         <div class="px-4 py-2 bg-gray-50">
@@ -31,7 +31,7 @@
           :table="table"
           :showColumns="table.name == showTableKey"
           @click="onClick(table.name)"
-          @dblclick="onDblClick(table)"
+          @search="onSearch"
         />
         <div v-if="filteredTables.length == 0" class="block bg-white hover:bg-gray-50">
           <p class="px-4 py-4 sm:px-6">No tables</p>
@@ -145,7 +145,7 @@ const onClick = (key: string) => {
   }
 }
 
-const onDblClick = (table: Table) => {
+const onSearch = (table: Table) => {
   editor.query.sql = `SELECT * FROM "${table.schema}"."${table.name}";`
   searchTablesInput.value = '' // reset input
   editor.runQuery()

--- a/view/src/components/DatabaseExplorerItems.vue
+++ b/view/src/components/DatabaseExplorerItems.vue
@@ -1,33 +1,39 @@
 <template>
-  <div class="block hover:bg-gray-50">
-    <!--  @click="onClick" v-on:dblclick="onDblClick" -->
-    <div class="px-4 py-4 sm:px-6">
-      <div class="flex items-center justify-between">
+  <div class="block hover:bg-gray-50 group" @click="$emit('click')">
+    <div class="px-4 py-4 space-y-2">
+      <div class="flex items-center justify-between relative">
         <div
           :class="
-            cn('text-sm truncate text-gray-600', {
+            cn('text-sm truncate ', {
               'font-medium': props.isUsed
             })
           "
         >
           {{ props.table.schema }}.{{ props.table.name }}
         </div>
+
+        <Button
+          @click.stop="$emit('search', table)"
+          title="Select all from table"
+          variant="ghost"
+          class="absolute right-0 opacity-0 group-hover:opacity-100"
+          size="sm"
+        >
+          <Search class="text-gray-600" />
+        </Button>
       </div>
-      <div class="flex justify-between">
+      <div v-if="props.showColumns" class="flex justify-between">
         <div class="sm:flex">
-          <div class="flex items-center text-sm text-gray-500">
+          <div class="flex items-center text-sm text-muted-foreground">
             {{ table.description }}
           </div>
         </div>
       </div>
-      <div v-if="props.showColumns">
-        <div v-for="column in table.columns" :key="column.id">
-          <div class="mt-2 flex justify-between">
-            <div class="sm:flex">
-              <div class="flex items-center text-sm text-gray-500">
-                {{ column.name }}: {{ column.type }}
-              </div>
-            </div>
+      <div v-if="props.showColumns" class="space-y-1">
+        <div v-for="column in table.columns" :key="column.id" class="space-y-1">
+          <div class="flex justify-between text-muted-foreground text-sm">
+            <span>{{ column.name }}</span>
+            <span>{{ column.type }}</span>
           </div>
         </div>
       </div>
@@ -39,6 +45,8 @@
 import { cn } from '@/lib/utils'
 import type { Table } from '@/stores/tables'
 import { defineProps } from 'vue'
+import { Search } from 'lucide-vue-next'
+import { Button } from './ui/button'
 
 const props = defineProps({
   table: {
@@ -54,4 +62,6 @@ const props = defineProps({
     default: false
   }
 })
+
+defineEmits(['search', 'click'])
 </script>


### PR DESCRIPTION
J'en profite pour en faire 2:
https://linear.app/myriade/issue/DEV-409/on-databaseexplorer-instead-of-doubleclicking-to-explore-the-table-add
https://linear.app/myriade/issue/DEV-422/ui-database-explore-only-dispaly-the-table-description-when-clicked