### PR TITLE
clean: remove select databaseId (we use contextStore now)

### DIFF
--- a/view/package.json
+++ b/view/package.json
@@ -30,7 +30,6 @@
     "clsx": "^2.1.1",
     "diff": "^8.0.2",
     "echarts": "^6.0.0",
-    "js-yaml": "^4.1.0",
     "lucide-vue-next": "^0.542.0",
     "marked": "^14.0.0",
     "notiwind": "^2.1.0",
@@ -53,7 +52,6 @@
   "devDependencies": {
     "@eslint/js": "^9.22.0",
     "@types/diff": "^8.0.0",
-    "@types/js-yaml": "^4.0.9",
     "@types/node": "^18.14.2",
     "@vitejs/plugin-vue": "^5.2.3",
     "@vue/tsconfig": "^0.7.0",

--- a/view/src/components/DatabaseExplorer.vue
+++ b/view/src/components/DatabaseExplorer.vue
@@ -42,9 +42,9 @@
 </template>
 
 <script setup lang="ts">
-import { Input } from '@/components/ui/input'
-import { Card, CardHeader, CardTitle } from '@/components/ui/card'
 import DatabaseExplorerItems from '@/components/DatabaseExplorerItems.vue'
+import { Card, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
 import { useQueryEditor } from '@/composables/useQueryEditor'
 import { useDatabasesStore } from '@/stores/databases'
 import type { Table } from '@/stores/tables'

--- a/view/src/components/FunctionCallRenderer.vue
+++ b/view/src/components/FunctionCallRenderer.vue
@@ -93,7 +93,6 @@ import MarkdownDisplay from '@/components/MarkdownDisplay.vue'
 const props = defineProps<{
   functionCall: FunctionCall
   queryId?: string
-  databaseSelectedId?: string | null
 }>()
 
 const argumentsNameToHide = [

--- a/view/src/components/base/BaseEditorPreview.vue
+++ b/view/src/components/base/BaseEditorPreview.vue
@@ -29,8 +29,7 @@ import { Button } from '../ui/button'
 const { fetchQuery, fetchQueryResults } = useQueryEditor()
 
 const props = defineProps({
-  queryId: String,
-  databaseId: String
+  queryId: String
 })
 
 const rows = ref([])

--- a/view/src/components/database/DatabaseForm.vue
+++ b/view/src/components/database/DatabaseForm.vue
@@ -146,6 +146,7 @@
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import axios from '@/plugins/axios'
+import { useContextsStore } from '@/stores/contexts'
 import {
   getDatabaseTypeName,
   getDefaultDetailsForEngine,
@@ -178,6 +179,7 @@ const emit = defineEmits<{
 
 // Stores
 const databasesStore = useDatabasesStore()
+const contextsStore = useContextsStore()
 
 // State
 const database = reactive<Database>(makeEmptyDatabase())
@@ -187,7 +189,6 @@ if (props.engine) {
 const isTestingConnection = ref(false)
 const isSaving = ref(false)
 const connectionStatus = ref<{ type: 'success' | 'error'; message: string } | null>(null)
-const isDbtSupportOpen = ref(false)
 
 // DBT-related state
 const isValidatingRepo = ref(false)
@@ -301,9 +302,9 @@ const handleSave = async () => {
       result = await databasesStore.updateDatabase(database.id, database)
     } else {
       result = await databasesStore.createDatabase(database)
-      // Set as selected and refresh list for create mode
-      databasesStore.setDatabaseSelected(result)
+      // Set the new database as the selected context
       await databasesStore.fetchDatabases({ refresh: true })
+      contextsStore.setSelectedContext(`database-${result.id}`)
     }
 
     emit('saved', result)
@@ -380,9 +381,6 @@ const generateDbtDocs = async () => {
   }
 }
 
-const toggleDbtSupport = () => {
-  isDbtSupportOpen.value = !isDbtSupportOpen.value
-}
 // Expose methods for parent components
 defineExpose({
   testConnection,

--- a/view/src/composables/useQueryEditor.ts
+++ b/view/src/composables/useQueryEditor.ts
@@ -1,7 +1,7 @@
+import { formatSQL } from '@/lib/utils'
 import axios from '@/plugins/axios'
 import router from '@/router'
-import { useDatabasesStore } from '@/stores/databases'
-import { formatSQL } from '@/lib/utils'
+import { useContextsStore } from '@/stores/contexts'
 import { computed, reactive, ref } from 'vue'
 
 export interface Query {
@@ -80,9 +80,9 @@ const loadQuery = async (id: string) => {
   query.sql = q.sql || ''
   query.is_favorite = q.is_favorite
 
-  // Select DB in the databases store
-  const databasesStore = useDatabasesStore()
-  await databasesStore.selectDatabaseById(q.databaseId)
+  // Select context from the query
+  const contextsStore = useContextsStore()
+  contextsStore.setSelectedContext(`database-${q.databaseId}`)
   databaseId.value = q.databaseId
   if (query.sql) runQuery()
 }

--- a/view/src/stores/databases.ts
+++ b/view/src/stores/databases.ts
@@ -98,11 +98,6 @@ export const useDatabasesStore = defineStore('databases', () => {
   // --------------------------------------------------------------------------
   // ACTIONS
   // --------------------------------------------------------------------------
-  function setDatabaseSelected(newDatabase: Database) {
-    databaseSelectedId.value = newDatabase.id
-    localStorage.setItem('databaseId', String(newDatabase.id))
-  }
-
   async function fetchDatabases({ refresh }: { refresh: boolean }) {
     if (databases.value.length > 0 && !refresh) return
 
@@ -121,11 +116,6 @@ export const useDatabasesStore = defineStore('databases', () => {
 
   function fetchDatabaseTables(databaseId: string) {
     return axios.get(`/api/databases/${databaseId}/schema`).then((res) => res.data)
-  }
-
-  function selectDatabaseById(id: string) {
-    databaseSelectedId.value = id
-    localStorage.setItem('databaseId', String(id))
   }
 
   function updateDatabase(id: string, database: Database) {
@@ -164,10 +154,8 @@ export const useDatabasesStore = defineStore('databases', () => {
     sortedDatabases,
     hasOnlyPublicDatabases,
     // actions
-    setDatabaseSelected,
     fetchDatabases,
     fetchDatabaseTables,
-    selectDatabaseById,
     updateDatabase,
     createDatabase,
     deleteDatabase,

--- a/view/yarn.lock
+++ b/view/yarn.lock
@@ -957,11 +957,6 @@
   resolved "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz"
   integrity sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==
 
-"@types/js-yaml@^4.0.9":
-  version "4.0.9"
-  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.9.tgz#cd82382c4f902fed9691a2ed79ec68c5898af4c2"
-  integrity sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==
-
 "@types/json-schema@^7.0.15":
   version "7.0.15"
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz"


### PR DESCRIPTION
- remove js-yaml
- remove unused databaseSelectedId
- remove selectDatabaseById (we use selectContext)
- Automatically select the newly created database connection as the active context to improve user experience.