### PR TITLE
feat: add auto-scroll

### DIFF
--- a/view/src/stores/conversations.ts
+++ b/view/src/stores/conversations.ts
@@ -32,13 +32,15 @@ export interface Message {
   id: string
   createdAt: Date
   role: 'user' | 'assistant' | 'function' | 'system'
-  content: string
+  // Content could be string or array of this type: {type: 'text'|'query'|'image', query_id?: string}
+  content: string | any
   isAnswer?: boolean
   functionCall?: {
     name: string
     arguments: any
     metadata?: Record<string, unknown>
   }
+  conversationId: string
   functionCallId?: string
   queryId?: string
   image?: string // base64 encoded image


### PR DESCRIPTION
En draft pour le moment.
Pour corriger le fait que lorsqu'on a un chat qui contient des requêtes cela fait que le scroll arrive au mauvais endroit, j'utilise un `mutationObserver` qui va check les changements dans le DOM et scroll une fois ces derniers terminés.

Le problème avec cette solution est que le scroll n'est pas instanté, j'ai pour l'instant mis en mode smooth pour éviter un changement trop brut. 

**--> À l'arrivée sur le chat, on pourrait attendre que les résultats des requêtes soit arrivés avant d'afficher le chat et donc d'avoir la position du scroll au bon endroit.**

https://github.com/user-attachments/assets/d3bb3a17-68ab-401e-9143-7c1b5413958f


https://linear.app/myriade/issue/DEV-411/lors-de-larrive-sur-un-chat-il-faut-scroller-tout-en-bas-pour-voir-les
https://linear.app/myriade/issue/DEV-412/lors-de-lenvoi-dun-message-scroller-pour-etre-en-bas-de-la
https://linear.app/myriade/issue/DEV-413/lors-de-lajout-dun-message-a-la-conversation-venant-du-serveur-si